### PR TITLE
Support animating DOM properties like scrollTop

### DIFF
--- a/src/dynamics.coffee
+++ b/src/dynamics.coffee
@@ -70,6 +70,8 @@ applyProperties = (el, properties) ->
         v = "#{v}#{unitForProperty(k, v)}"
       if isSVG && svgProperties.contains(k)
         el.setAttribute(k, v)
+      else if k of el # support animating scrollTop, etc
+        el[k] = v
       else
         el.style[propertyWithPrefix(k)] = v
 

--- a/test/dynamics.coffee
+++ b/test/dynamics.coffee
@@ -73,6 +73,19 @@ describe 'dynamics.animate', ->
       done()
     , 50
 
+  it 'animate scrollTop of a DOM element', (done) ->
+    el = document.createElement('div')
+    dynamics.animate(el, {
+      scrollTop: 100,
+    }, {
+      duration: 25,
+      type: dynamics.easeInOut
+    })
+    setTimeout ->
+      expect(el.scrollTop).eql('100')
+      done()
+    , 50
+
   it 'animate with a delay', (done) ->
     el = document.createElement('div')
     el.style.left = 0


### PR DESCRIPTION
Before, only properties inside `style` were animated by `dynamics.js`. This PR first checks for properties belonging to the element, and then opts to animate `style` properties. I think this falls in line with how dynamics.js animates arbitrary javascript objects too.