### PR TITLE
Fixed a bug with Chrome 52

### DIFF
--- a/src/dynamics.coffee
+++ b/src/dynamics.coffee
@@ -173,7 +173,7 @@ getCurrentProperties = (el, keys) ->
           properties['transform'] = matrix.decompose()
       else
         v = style[key]
-        if !v? && key != 'd' && svgProperties.contains(key)
+        if (!v? || key is 'd' && svgProperties.contains(key)
           v = el.getAttribute(key)
         if v == "" or !v?
           v = defaultValueForKey(key)

--- a/src/dynamics.coffee
+++ b/src/dynamics.coffee
@@ -173,7 +173,7 @@ getCurrentProperties = (el, keys) ->
           properties['transform'] = matrix.decompose()
       else
         v = style[key]
-        if !v? && svgProperties.contains(key)
+        if !v? && key != 'd' && svgProperties.contains(key)
           v = el.getAttribute(key)
         if v == "" or !v?
           v = defaultValueForKey(key)


### PR DESCRIPTION
I animate <path> with d and apparently since chrome52 path have now a computedStyle for d (something like path(M023 003...) that prevent dynamics.js from loading d from getAttribute.
