### PR TITLE
Fixed a bug with SVG on Chrome 52

### DIFF
--- a/src/dynamics.coffee
+++ b/src/dynamics.coffee
@@ -173,7 +173,7 @@ getCurrentProperties = (el, keys) ->
           properties['transform'] = matrix.decompose()
       else
         v = style[key]
-        if !v? && svgProperties.contains(key)
+        if (!v? or key is 'd') && svgProperties.contains(key)
           v = el.getAttribute(key)
         if v == "" or !v?
           v = defaultValueForKey(key)

--- a/test/dynamics.coffee
+++ b/test/dynamics.coffee
@@ -253,6 +253,30 @@ describe 'dynamics.animate', ->
       done()
     , 150
 
+
+  it 'animates the points of a svg path correctly', (done) ->
+    el = document.createElement('path')
+
+    # On chrome 52 getComputedStyle give a "d" property for path
+    # Mock window.getComputedStyle
+    style = window.getComputedStyle(el, null)
+    style.setProperty('d', 'path(10 20 30)')
+    oldComputed = window.getComputedStyle
+    window.getComputedStyle = (el, pseudoElt) -> style
+
+    dynamics.tests.isSVG = (el) -> true
+    el.setAttribute("d", "M101.88,22 C101.88,18.25")
+    dynamics.animate(el, {
+      d: "M50,10 C88.11,20.45"
+    }, {
+      duration: 100
+    })
+    setTimeout ->
+      expect(el.getAttribute("d")[0]).to.be.equal('M')
+      window.getComputedStyle = oldComputed # remove mock to avoid conflict for the next test
+      done()
+    , 50
+
   it 'animates properties of an object correctly', (done) ->
     assertTypes = (object) ->
       expect(typeof(object.number)).to.be.equal('number', 'object.number has the wrong type')


### PR DESCRIPTION
I animate with `d` and apparently since chrome52 `path` has a computedStyle for `d` (something like `path(M023 003...)` that prevents dynamics.js from loading `d` from getAttribute.
