### PR TITLE
Add build step to prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script/register",
     "build": "coffee -c -o ./lib/ ./src/dynamics.coffee && ./node_modules/uglify-js/bin/uglifyjs ./lib/dynamics.js -m -c -o ./lib/dynamics.min.js",
-    "build:watch": "coffee -w -c -o ./lib/ ./src/dynamics.coffee"
+    "build:watch": "coffee -w -c -o ./lib/ ./src/dynamics.coffee",
+    "prepublish": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/michaelvillar/dynamics.js/issues"


### PR DESCRIPTION
Latest npm package is missing the lib directory, this change will make sure that doesn't happen again