### PR TITLE
Fix crash for interleaving animations + modernise dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "url": "https://github.com/michaelvillar/dynamics.js"
   },
   "devDependencies": {
-    "coffee-script": "1.7.1",
-    "uglify-js": "2.4.14",
-    "jsdom": "3.x.x",
-    "mocha-jsdom": "0.4.0",
-    "chai": "3.0.0",
-    "mocha": "2.2.5"
+    "coffeescript": "1.12.7",
+    "uglify-js": "2.8.29",
+    "jsdom": "13.x.x",
+    "mocha-jsdom": "2.0.0",
+    "chai": "4.2.0",
+    "mocha": "5.2.0"
   },
   "scripts": {
-    "test": "mocha --compilers coffee:coffee-script/register",
+    "test": "mocha --compilers coffee:coffeescript/register",
     "build": "coffee -c -o ./lib/ ./src/dynamics.coffee && ./node_modules/uglify-js/bin/uglifyjs ./lib/dynamics.js -m -c -o ./lib/dynamics.min.js",
     "build:watch": "coffee -w -c -o ./lib/ ./src/dynamics.coffee",
     "prepublish": "npm run build"

--- a/src/dynamics.coffee
+++ b/src/dynamics.coffee
@@ -1091,7 +1091,7 @@ runLoopTick = (t) ->
   # Animations
   toRemoveAnimations = []
   for animation in animations
-    toRemoveAnimations.push(animation) unless animationTick(t, animation)
+    toRemoveAnimations.push(animation) unless animation && animationTick(t, animation)
   animations = animations.filter (animation) ->
     toRemoveAnimations.indexOf(animation) == -1
 

--- a/src/dynamics.coffee
+++ b/src/dynamics.coffee
@@ -36,7 +36,7 @@ cacheFn = (func) ->
 # Make a function accept array or single objects for the first argument
 makeArrayFn = (fn) ->
   (el) ->
-    if el instanceof Array or el instanceof NodeList or el instanceof HTMLCollection
+    if el.hasOwnProperty("length")
       res = for i in [0...el.length]
         args = Array.prototype.slice.call(arguments, 1)
         args.splice(0, 0, el[i])

--- a/test/dynamics.coffee
+++ b/test/dynamics.coffee
@@ -4,7 +4,7 @@ expect = require('chai').expect
 assert = require('chai').assert
 dynamics = require('../src/dynamics')
 
-jsdom()
+jsdom({url: 'http://localhost'})
 
 dynamics.tests =
   matrixForTransform: (transform) ->
@@ -82,7 +82,7 @@ describe 'dynamics.animate', ->
       type: dynamics.easeInOut
     })
     setTimeout ->
-      expect(el.scrollTop).eql('100')
+      expect(el.scrollTop).eql(100)
       done()
     , 50
 

--- a/test/dynamics.coffee
+++ b/test/dynamics.coffee
@@ -216,6 +216,25 @@ describe 'dynamics.animate', ->
         done()
     })
 
+  it 'does not crash if dynamics.stop is called in complete and two animations are active', (done) ->
+    el = document.createElement('div')
+    el2 = document.createElement('div')
+
+    dynamics.animate(el, {
+      left: 100
+    }, {
+       duration: 25,
+       complete: ->
+         dynamics.stop(el)
+    })
+    dynamics.animate(el2, {
+      left: 100
+    }, {
+       duration: 100,
+       complete: ->
+         done()
+    })
+
   it 'comes back to the original value with dynamics.bounce', (done) ->
     el = document.createElement('div')
     dynamics.animate(el, {


### PR DESCRIPTION
This PR:

* Modernises all dependencies (couldn't get it to build on my machine with the existing ones)
* Fixes a bug where calling `dynamics.stop` in `complete` for example with another interleaved animation in place caused a crash. Also added a test. This happens frequently when combined with react animations since the react lifecycle `componentWillLeave(callback)` will call `componentWillUnmount` once `callback` is called (synchronously) which usually should call `dynamics.stop`. 